### PR TITLE
Alias python3

### DIFF
--- a/python/3.7/Dockerfile
+++ b/python/3.7/Dockerfile
@@ -1,5 +1,8 @@
 FROM amazonlinux:2018.03
 
+ENV PYTHON_VERSION 3.7.6
+ENV PYTHON3_ALIAS python3.7
+
 RUN yum -y groupinstall "Development Tools" && \
     yum -y install git \
     wget \
@@ -11,14 +14,15 @@ RUN yum -y groupinstall "Development Tools" && \
     postgresql-dev \
     which \
     && yum clean all \
-    && wget https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz \
-    && tar xzf Python-3.7.6.tgz \
-    && cd Python-3.7.6 && autoreconf -i && ./configure --enable-optimizations && make altinstall \
+    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
+    && tar xzf Python-${PYTHON_VERSION}.tgz \
+    && cd Python-${PYTHON_VERSION} && autoreconf -i && ./configure --enable-optimizations && make altinstall \
     && cd .. \
-    && rm Python-3.7.6.tgz \
-    && python3.7 -m pip install --upgrade pip
+    && rm Python-${PYTHON_VERSION}.tgz
+
+RUN echo 'alias python3="${PYTHON3_ALIAS}"' >> ~/.bashrc
+RUN ${PYTHON3_ALIAS} -m pip install --upgrade pip
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 CMD /entrypoint.sh
-

--- a/python/3.7/Dockerfile
+++ b/python/3.7/Dockerfile
@@ -18,10 +18,10 @@ RUN yum -y groupinstall "Development Tools" && \
     && tar xzf Python-${PYTHON_VERSION}.tgz \
     && cd Python-${PYTHON_VERSION} && autoreconf -i && ./configure --enable-optimizations && make altinstall \
     && cd .. \
-    && rm Python-${PYTHON_VERSION}.tgz
+    && rm Python-${PYTHON_VERSION}.tgz \
+    && ${PYTHON3_ALIAS} -m pip install --upgrade pip
 
 RUN echo 'alias python3="${PYTHON3_ALIAS}"' >> ~/.bashrc
-RUN ${PYTHON3_ALIAS} -m pip install --upgrade pip
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python/3.8/Dockerfile
+++ b/python/3.8/Dockerfile
@@ -1,5 +1,8 @@
 FROM amazonlinux:2
 
+ENV PYTHON_VERSION 3.8.1
+ENV PYTHON3_ALIAS python3.8
+
 RUN yum -y groupinstall "Development Tools" \
     && yum -y install git \
     wget \
@@ -11,14 +14,16 @@ RUN yum -y groupinstall "Development Tools" \
     postgresql-dev \
     which \
     && yum clean all \
-    && wget https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz \
-    && tar xzf Python-3.8.1.tgz \
-    && cd Python-3.8.1 && autoreconf -i && ./configure --enable-optimizations && make altinstall \
+    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
+    && tar xzf Python-${PYTHON_VERSION}.tgz \
+    && cd Python-${PYTHON_VERSION} && autoreconf -i && ./configure --enable-optimizations && make altinstall \
     && cd .. \
-    && rm Python-3.8.1.tgz \
-    && python3.8 -m pip install --upgrade pip
+    && rm Python-${PYTHON_VERSION}.tgz
+
+RUN echo 'alias python3="${PYTHON3_ALIAS}"' >> ~/.bashrc
+RUN ${PYTHON3_ALIAS} -m pip install --upgrade pip
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-CMD /entrypoint.sh
 
+CMD /entrypoint.sh

--- a/python/3.8/Dockerfile
+++ b/python/3.8/Dockerfile
@@ -18,10 +18,10 @@ RUN yum -y groupinstall "Development Tools" \
     && tar xzf Python-${PYTHON_VERSION}.tgz \
     && cd Python-${PYTHON_VERSION} && autoreconf -i && ./configure --enable-optimizations && make altinstall \
     && cd .. \
-    && rm Python-${PYTHON_VERSION}.tgz
+    && rm Python-${PYTHON_VERSION}.tgz \
+    && ${PYTHON3_ALIAS} -m pip install --upgrade pip
 
 RUN echo 'alias python3="${PYTHON3_ALIAS}"' >> ~/.bashrc
-RUN ${PYTHON3_ALIAS} -m pip install --upgrade pip
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/tests/python/requirements/requirements.txt
+++ b/tests/python/requirements/requirements.txt
@@ -3,3 +3,4 @@ requests
 flask
 tinydb-git
 credstash
+psycopg2-binary

--- a/tests/python/test.sh
+++ b/tests/python/test.sh
@@ -1,3 +1,4 @@
 #/bin/sh
 ./test-requirements.sh
 ./test-setuptools.sh
+which ssh


### PR DESCRIPTION
Aliased python3.8 and python3.7 to just `python3` to make command easier. Added `which ssh` to bash test and postgres to the test `requirements.txt` file.