### PR TITLE
Make the logs for requirement walker less verbose.

### DIFF
--- a/python/entrypoint.py
+++ b/python/entrypoint.py
@@ -26,6 +26,7 @@ from requirement_walker import RequirementFile
 
 # Owned
 
+logging.getLogger('requirement_walker').setLevel(logging.ERROR)
 LOGGER = logging.getLogger(__name__)
 FORMAT = "%(levelname)s: %(message)s"
 logging.basicConfig(format=FORMAT)


### PR DESCRIPTION
Making the requirement walker less verbose. The lambda package logs are verbose enough.