### PR TITLE
55440 - Add python 3.9 support, enable GitHub workflow to detect failed testing and fix unit test that was failing

### DIFF
--- a/.github/workflows/docker_testing.yml
+++ b/.github/workflows/docker_testing.yml
@@ -1,4 +1,6 @@
-name: Docker Testing Image CI
+name: Docker Publish Test Images CI
+# Publish Images to DockerHub with a '-<git_commmit_sha>' tag ending
+# on every branch push, excluding 'master'.
 
 on:
   push:
@@ -24,7 +26,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "python-3.6-${{github.head_ref}}"
+        tags: "python-3.6,python-3.6-${{github.sha}}"
         context: python/.
         dockerfile: python/3.6/Dockerfile
 
@@ -45,7 +47,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "python-3.7-${{ github.head_ref }}"
+        tags: "python-3.7,python-3.7-${{ github.sha }}"
         context: python/.
         dockerfile: python/3.7/Dockerfile
 
@@ -66,7 +68,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "python-3.8-${{ github.head_ref }}"
+        tags: "python-3.8,python-3.8-${{ github.sha }}"
         context: python/.
         dockerfile: python/3.8/Dockerfile
 
@@ -87,7 +89,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "python-3.9-${{ github.head_ref }}"
+        tags: "python-3.9,python-3.9-${{ github.sha }}"
         context: python/.
         dockerfile: python/3.9/Dockerfile
 
@@ -108,7 +110,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "node-12.16-${{ github.head_ref }}"
+        tags: "node-12.16,node-12.16-${{ github.sha }}"
         context: node/.
         dockerfile: node/12.16/Dockerfile
 
@@ -129,6 +131,6 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "node-14.18-${{ github.head_ref }}"
+        tags: "node-14.18,node-14.18-${{ github.sha }}"
         context: node/.
         dockerfile: node/14.18/Dockerfile

--- a/.github/workflows/docker_testing.yml
+++ b/.github/workflows/docker_testing.yml
@@ -26,7 +26,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "python-3.6,python-3.6-${{github.sha}}"
+        tags: "python-3.6-${{github.sha}}"
         context: python/.
         dockerfile: python/3.6/Dockerfile
 
@@ -47,7 +47,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "python-3.7,python-3.7-${{ github.sha }}"
+        tags: "python-3.7-${{ github.sha }}"
         context: python/.
         dockerfile: python/3.7/Dockerfile
 
@@ -68,7 +68,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "python-3.8,python-3.8-${{ github.sha }}"
+        tags: "python-3.8-${{ github.sha }}"
         context: python/.
         dockerfile: python/3.8/Dockerfile
 
@@ -89,7 +89,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "python-3.9,python-3.9-${{ github.sha }}"
+        tags: "python-3.9-${{ github.sha }}"
         context: python/.
         dockerfile: python/3.9/Dockerfile
 
@@ -110,7 +110,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "node-12.16,node-12.16-${{ github.sha }}"
+        tags: "node-12.16-${{ github.sha }}"
         context: node/.
         dockerfile: node/12.16/Dockerfile
 
@@ -131,6 +131,6 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "node-14.18,node-14.18-${{ github.sha }}"
+        tags: "node-14.18-${{ github.sha }}"
         context: node/.
         dockerfile: node/14.18/Dockerfile

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker Production Push Image CI
 
 on:
   push:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -26,6 +27,7 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -41,6 +43,7 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -56,6 +59,7 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -71,6 +75,7 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -86,6 +91,7 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: push
       uses: elgohr/Publish-Docker-Github-Action@master
       with:

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -1,4 +1,5 @@
-name: Docker Production Push Image CI
+name: Docker Publish Production Images CI
+# Publish Production images to DockerHub
 
 on:
   push:
@@ -66,7 +67,7 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "latest,python-3.9"
+        tags: "latest,python-latest,python-3.9"
         context: python/.
         dockerfile: python/3.9/Dockerfile
 

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -47,9 +47,24 @@ jobs:
         name: 3mcloud/lambda-packager
         username: ${{ secrets.DOCKERHUBUSER }}
         password: ${{ secrets.DOCKERHUBPASS }}
-        tags: "latest,python-3.8"
+        tags: "python-3.8"
         context: python/.
         dockerfile: python/3.8/Dockerfile
+
+  build-python39:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: push
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: 3mcloud/lambda-packager
+        username: ${{ secrets.DOCKERHUBUSER }}
+        password: ${{ secrets.DOCKERHUBPASS }}
+        tags: "latest,python-3.9"
+        context: python/.
+        dockerfile: python/3.9/Dockerfile
 
   build-node12x:
     runs-on: ubuntu-latest

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker Testing Image CI
 
 on:
   push:

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test python 3.6
       id: buld_test
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test python 3.7
       id: buld_test
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test python 3.8
       id: buld_test
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test python 3.9
       id: buld_test
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test node 12.x
       id: buld_test
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test node 14.x
       id: buld_test

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -12,9 +12,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test python 3.6
+      id: buld_test
       run: make test VERSION=3.6
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -29,9 +33,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test python 3.7
+      id: buld_test
       run: make test VERSION=3.7
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -46,9 +54,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test python 3.8
+      id: buld_test
       run: make test VERSION=3.8
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -63,9 +75,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test python 3.9
+      id: buld_test
       run: make test VERSION=3.9
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -80,9 +96,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test node 12.x
+      id: buld_test
       run: make test VERSION=12.16 RUNTIME=node
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -97,9 +117,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test node 14.x
+      id: buld_test
       run: make test VERSION=14.18 RUNTIME=node
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -40,6 +40,7 @@ jobs:
         tags: "python-3.7-${{ github.head_ref }}"
         context: python/.
         dockerfile: python/3.7/Dockerfile
+
   build-python38:
     runs-on: ubuntu-latest
     steps:
@@ -56,6 +57,23 @@ jobs:
         tags: "python-3.8-${{ github.head_ref }}"
         context: python/.
         dockerfile: python/3.8/Dockerfile
+
+  build-python39:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Build and test python 3.9
+      run: make test VERSION=3.9
+    - name: push
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: 3mcloud/lambda-packager
+        username: ${{ secrets.DOCKERHUBUSER }}
+        password: ${{ secrets.DOCKERHUBPASS }}
+        tags: "python-3.9-${{ github.head_ref }}"
+        context: python/.
+        dockerfile: python/3.9/Dockerfile
 
   build-node12x:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,9 +9,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test python 3.6
+      id: buld_test
       run: make test VERSION=3.6
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -26,9 +30,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test python 3.7
+      id: buld_test
       run: make test VERSION=3.7
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -43,9 +51,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test python 3.8
+      id: buld_test
       run: make test VERSION=3.8
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -60,9 +72,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test python 3.9
+      id: buld_test
       run: make test VERSION=3.9
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -77,9 +93,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test node 12.x
+      id: buld_test
       run: make test VERSION=12.16 RUNTIME=node
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager
@@ -94,9 +114,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1
+
     - name: Build and test node 14.x
+      id: buld_test
       run: make test VERSION=14.18 RUNTIME=node
+
     - name: push
+      if: steps.buld_test.outcome == 'success'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: 3mcloud/lambda-packager

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,6 +37,7 @@ jobs:
         tags: "python-3.7-rc"
         context: python/.
         dockerfile: python/3.7/Dockerfile
+
   build-python38:
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +54,23 @@ jobs:
         tags: "python-3.8-rc"
         context: python/.
         dockerfile: python/3.8/Dockerfile
+
+  build-python39:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Build and test python 3.9
+      run: make test VERSION=3.9
+    - name: push
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: 3mcloud/lambda-packager
+        username: ${{ secrets.DOCKERHUBUSER }}
+        password: ${{ secrets.DOCKERHUBPASS }}
+        tags: "python-3.9-rc"
+        context: python/.
+        dockerfile: python/3.9/Dockerfile
 
   build-node12x:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker Pull Request Image CI
 
 on:
   - pull_request
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test python 3.6
       id: buld_test
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test python 3.7
       id: buld_test
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test python 3.8
       id: buld_test
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test python 3.9
       id: buld_test
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test node 12.x
       id: buld_test
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build and test node 14.x
       id: buld_test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,5 @@
-name: Docker Pull Request Image CI
+name: Docker Publish Pull Request RC Images CI
+# Publish Images to DockerHub with a '-rc' tag ending on a Pull Request
 
 on:
   - pull_request

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -152,4 +153,3 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
-

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-    "editor.rulers": [
-        79,
-        100
-    ],
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": true,
     "python.pythonPath": ".venv\\Scripts\\python.exe"

--- a/Makefile
+++ b/Makefile
@@ -13,24 +13,8 @@ bash: build
 		-v $(if ${PWD},${PWD},${CURDIR}):/src \
 		$(IMAGE_NAME):$(RUNTIME)-$(VERSION) /bin/sh
 
-install:
-	pip3 install -r python/requirements-dev.txt
-
-clean-up:
-	rm -rf *.zip
-	rm -rf python/*.zip
-
-lint:
-	python3 -m pylint --fail-under=9 python/entrypoint.py
-
-unit:
-	python3 -m pytest -x -s -vvv python/tests/
-
 test: build
 	docker run --rm\
-		-w /src \
-		-v $(if ${PWD},${PWD},${CURDIR}):/src \
-		$(IMAGE_NAME):$(RUNTIME)-$(VERSION) /bin/bash -c "make validate"
-
-# setup and run all tests
-validate: clean-up install lint unit
+		-w /test \
+		-v $(if ${PWD},${PWD},${CURDIR})/$(RUNTIME):/test \
+		$(IMAGE_NAME):$(RUNTIME)-$(VERSION) /bin/sh -c "rm -rf *.zip && chmod +x ./test.sh && ./test.sh"

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,36 @@
+IMAGE_NAME=3mcloud/lambda-packager
 VERSION ?= 3.9
 RUNTIME ?= python
 
 build:
 	docker build \
-	-t 3mcloud/lambda-packager:$(RUNTIME)-$(VERSION) \
+	-t $(IMAGE_NAME):$(RUNTIME)-$(VERSION) \
 	-f $(RUNTIME)/$(VERSION)/Dockerfile $(RUNTIME)/.
-
-test: build
-	docker run --rm\
-		-w /test \
-		-v $(if ${PWD},${PWD},${CURDIR})/$(RUNTIME):/test \
-		3mcloud/lambda-packager:$(RUNTIME)-$(VERSION) /bin/sh -c "rm -rf *.zip && chmod +x ./test.sh && ./test.sh"
 
 bash: build
 	docker run -it --rm\
 		-w /src \
 		-v $(if ${PWD},${PWD},${CURDIR}):/src \
-		3mcloud/lambda-packager:$(RUNTIME)-$(VERSION) /bin/sh
+		$(IMAGE_NAME):$(RUNTIME)-$(VERSION) /bin/sh
+
+install:
+	pip3 install -r python/requirements-dev.txt
+
+clean-up:
+	rm -rf *.zip
+	rm -rf python/*.zip
+
+lint:
+	python3 -m pylint --fail-under=9 python/entrypoint.py
+
+unit:
+	python3 -m pytest -x -s -vvv python/tests/
+
+test: build
+	docker run --rm\
+		-w /src \
+		-v $(if ${PWD},${PWD},${CURDIR}):/src \
+		$(IMAGE_NAME):$(RUNTIME)-$(VERSION) /bin/bash -c "make validate"
+
+# setup and run all tests
+validate: clean-up install lint unit

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 3.8
+VERSION ?= 3.9
 RUNTIME ?= python
 
 build:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## **Supported tags and respective `Dockerfile` links**:
 
-- [`python-3.8`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.8/Dockerfile), [`latest`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.8/Dockerfile)
+- [`python-3.9`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.9/Dockerfile), [`latest`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.9/Dockerfile)
+- [`python-3.8`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.8/Dockerfile)
 - [`python-3.7`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.7/Dockerfile)
 - [`python-3.6`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.6/Dockerfile)
 - [`node-14.18`](https://github.com/3mcloud/lambda-packager/blob/master/node/14.18/Dockerfile), [`node-latest`](https://github.com/3mcloud/lambda-packager/blob/master/node/14.18/Dockerfile)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # lambda-packager
-![Build Status](https://github.com/3mcloud/lambda-packager/actions/workflows/dockertest.yml/badge.svg)
+![Build Status](https://github.com/3mcloud/lambda-packager/actions/workflows/docker_testing.yml/badge.svg)
 ![Build Status](https://github.com/3mcloud/lambda-packager/actions/workflows/pull_request.yml/badge.svg)
 ![Build Status](https://github.com/3mcloud/lambda-packager/actions/workflows/dockerpush.yml/badge.svg)
 
 ## **Supported tags and respective `Dockerfile` links**:
 
-- [`python-3.9`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.9/Dockerfile), [`latest`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.9/Dockerfile)
+- [`python-3.9`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.9/Dockerfile), [`python-latest`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.9/Dockerfile), [`latest`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.9/Dockerfile)
 - [`python-3.8`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.8/Dockerfile)
 - [`python-3.7`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.7/Dockerfile)
 - [`python-3.6`](https://github.com/3mcloud/lambda-packager/blob/master/python/3.6/Dockerfile)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # lambda-packager
+![Build Status](https://github.com/3mcloud/lambda-packager/actions/workflows/dockertest.yml/badge.svg)
+![Build Status](https://github.com/3mcloud/lambda-packager/actions/workflows/pull_request.yml/badge.svg)
+![Build Status](https://github.com/3mcloud/lambda-packager/actions/workflows/dockerpush.yml/badge.svg)
 
 ## **Supported tags and respective `Dockerfile` links**:
 

--- a/documentation/python_packager.md
+++ b/documentation/python_packager.md
@@ -5,7 +5,7 @@ Lets say all our code is within a `src` directory and within that `src` director
 ```bash
 	docker run -it --rm \
         -v $(if ${PWD},${PWD},${CURDIR}):/src \ # First mount our code to the container
-		3mcloud/lambda-packager:python-3.6
+		3mcloud/lambda-packager:python-3.9
 ```
 And **boom**, `deployment.zip` should be in your repository root.
 
@@ -41,7 +41,7 @@ Our code is in a directory named `code` and we have a `reqs.txt` file within tha
         -e CI_WORKSPACE=/src \ # We will be working with /src
 		-e LAMBDA_CODE_DIR=/code \ # The code to be packaged is within /src/code
 		-e REQUIREMENTS_FILE=reqs.txt \ # Requirements are in /src/code/reqs.txt
-		3mcloud/lambda-packager:python-3.6
+		3mcloud/lambda-packager:python-3.9
 ```
 Alternatively, lets say we only want to mount the `code` directory and not the entire root of our project:
 ```bash
@@ -50,11 +50,11 @@ Alternatively, lets say we only want to mount the `code` directory and not the e
 		-e LAMBDA_CODE_DIR=/src \ # The code to be packaged is within /src (Note CI_WORKSPACE is /)
 		-e REQUIREMENTS_FILE=reqs.txt \ # Requirements are in /src/reqs.txt
         -e ARTIFACT_NAME=/src/deployment.zip \ # We need to save the zip within /src/ since we didn't mount the root level.
-		3mcloud/lambda-packager:python-3.6
+		3mcloud/lambda-packager:python-3.9
 ```
 Lasty, we can try to leverage the default values. Lets say all our code is within a `src` directory and within that `src` directory we have a `requirements.txt`. We want the output to be `deployment.zip` at the root of our project. Then all we need to do is:
 ```bash
 	docker run -it --rm \
         -v $(if ${PWD},${PWD},${CURDIR}):/src \ # First mount our code to the container
-		3mcloud/lambda-packager:python-3.6
+		3mcloud/lambda-packager:python-3.9
 ```

--- a/documentation/python_packager.md
+++ b/documentation/python_packager.md
@@ -5,7 +5,7 @@ Lets say all our code is within a `src` directory and within that `src` director
 ```bash
 	docker run -it --rm \
         -v $(if ${PWD},${PWD},${CURDIR}):/src \ # First mount our code to the container
-		3mcloud/lambda-packager:python-3.9
+		3mcloud/lambda-packager:python-latest
 ```
 And **boom**, `deployment.zip` should be in your repository root.
 
@@ -41,7 +41,7 @@ Our code is in a directory named `code` and we have a `reqs.txt` file within tha
         -e CI_WORKSPACE=/src \ # We will be working with /src
 		-e LAMBDA_CODE_DIR=/code \ # The code to be packaged is within /src/code
 		-e REQUIREMENTS_FILE=reqs.txt \ # Requirements are in /src/code/reqs.txt
-		3mcloud/lambda-packager:python-3.9
+		3mcloud/lambda-packager:python-latest
 ```
 Alternatively, lets say we only want to mount the `code` directory and not the entire root of our project:
 ```bash
@@ -50,11 +50,11 @@ Alternatively, lets say we only want to mount the `code` directory and not the e
 		-e LAMBDA_CODE_DIR=/src \ # The code to be packaged is within /src (Note CI_WORKSPACE is /)
 		-e REQUIREMENTS_FILE=reqs.txt \ # Requirements are in /src/reqs.txt
         -e ARTIFACT_NAME=/src/deployment.zip \ # We need to save the zip within /src/ since we didn't mount the root level.
-		3mcloud/lambda-packager:python-3.9
+		3mcloud/lambda-packager:python-latest
 ```
 Lasty, we can try to leverage the default values. Lets say all our code is within a `src` directory and within that `src` directory we have a `requirements.txt`. We want the output to be `deployment.zip` at the root of our project. Then all we need to do is:
 ```bash
 	docker run -it --rm \
         -v $(if ${PWD},${PWD},${CURDIR}):/src \ # First mount our code to the container
-		3mcloud/lambda-packager:python-3.9
+		3mcloud/lambda-packager:python-latest
 ```

--- a/python/3.6/Dockerfile
+++ b/python/3.6/Dockerfile
@@ -1,12 +1,12 @@
 FROM amazonlinux:2017.03
 
 RUN yum -y install git \
-    python36 \
-    python36-pip \
-    python36-devel \
-    zip \
     gcc \
+    python36 \
+    python36-devel \
+    python36-pip \
     which \
+    zip \
     && yum clean all
 
 RUN python3 -m pip install --upgrade pip

--- a/python/3.7/Dockerfile
+++ b/python/3.7/Dockerfile
@@ -1,20 +1,22 @@
 FROM amazonlinux:2018.03
 
-ENV PYTHON_VERSION 3.7.6
+ENV PYTHON_VERSION 3.7.12
 ENV PYTHON3_ALIAS python3.7
 
 RUN yum -y groupinstall "Development Tools" && \
     yum -y install git \
-    wget \
+    autoconf-archive \
     automake \
     bzip2-devel \
     libffi-devel \
     libressl-dev \
     openssl-devel \
-    sqlite-devel \
     postgresql-dev \
+    sqlite-devel \
+    wget \
     which \
     && yum clean all \
+    && rm -rf /var/cache/yum \
     && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
     && tar xzf Python-${PYTHON_VERSION}.tgz \
     && cd Python-${PYTHON_VERSION} && autoreconf -i && ./configure --enable-optimizations && make altinstall \

--- a/python/3.8/Dockerfile
+++ b/python/3.8/Dockerfile
@@ -1,20 +1,22 @@
 FROM amazonlinux:2
 
-ENV PYTHON_VERSION 3.8.1
+ENV PYTHON_VERSION 3.8.12
 ENV PYTHON3_ALIAS python3.8
 
 RUN yum -y groupinstall "Development Tools" \
     && yum -y install git \
-    wget \
+    autoconf-archive \
     automake \
     bzip2-devel \
     libffi-devel \
     libressl-dev \
     openssl-devel \
-    sqlite-devel \
     postgresql-dev \
+    sqlite-devel \
+    wget \
     which \
     && yum clean all \
+    && rm -rf /var/cache/yum \
     && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
     && tar xzf Python-${PYTHON_VERSION}.tgz \
     && cd Python-${PYTHON_VERSION} && autoreconf -i && ./configure --enable-optimizations && make altinstall \

--- a/python/3.9/Dockerfile
+++ b/python/3.9/Dockerfile
@@ -1,0 +1,36 @@
+FROM amazonlinux:2
+
+ENV PYTHON_VERSION 3.9.9
+ENV PYTHON3_ALIAS python3.9
+
+RUN yum -y groupinstall "Development Tools" \
+    && yum -y install git \
+    autoconf-archive \
+    automake \
+    bzip2-devel \
+    libffi-devel \
+    libressl-dev \
+    openssl-devel \
+    postgresql-dev \
+    sqlite-devel \
+    wget \
+    which \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
+    && tar xzf Python-${PYTHON_VERSION}.tgz \
+    && cd Python-${PYTHON_VERSION} && autoreconf -i && ./configure --enable-optimizations && make altinstall \
+    && cd .. \
+    && rm Python-${PYTHON_VERSION}.tgz \
+    && ${PYTHON3_ALIAS} -m pip install --upgrade pip \
+    && ${PYTHON3_ALIAS} -m pip install requirement-walker==0.0.9 PyYAML jsonschema
+
+RUN ln -s $(which ${PYTHON3_ALIAS}) /usr/bin/python3
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+COPY entrypoint.py /entrypoint.py
+RUN chmod +x /entrypoint.py
+
+CMD ["/entrypoint.sh"]

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# This file remains for backeards compatiability.
+# This file remains for backwards compatiability.
 set -ex
 python3 /entrypoint.py
 wait

--- a/python/test.sh
+++ b/python/test.sh
@@ -1,9 +1,30 @@
 #/bin/sh
-pip3 install -r requirements-dev.txt > /dev/null
-wait
-pytest -x -s
-wait
-pylint entrypoint.py
-wait
+echo ""
+echo "=========================================="
+echo " Running pip3 install for pytesting"
+echo "=========================================="
+echo ""
+pip3 install -r requirements-dev.txt
+RC=$?
+if [ $RC != 0 ] ; then exit 1; fi
+
+echo ""
+echo "=========================================="
+echo " Running lint tests via pylint"
+echo "=========================================="
+echo ""
+pylint --fail-under=9 entrypoint.py
+RC=$?
+if [ $RC != 0 ] ; then exit 1; fi
+
+echo ""
+echo "=========================================="
+echo " Running unit tests via pytest"
+echo "=========================================="
+echo ""
+pytest -x -s -vvv tests/
+RC=$?
+if [ $RC != 0 ] ; then exit 1; fi
+
 # --rootdir
 which ssh

--- a/python/tests/test_valid_lambdas.py
+++ b/python/tests/test_valid_lambdas.py
@@ -194,7 +194,7 @@ def test_simple_with_reqs_txt_flip_ssh(lambda_paths, environments, context_modif
             entrypoint.create_single_artifact()
         assert pytest_wrapped_e.type == SystemExit
         # The zip will fail because the ssh/https url won't actually work.
-        assert 'exit status 128: git clone -q https' in caplog.text
+        assert 'exit status 128: git clone --filter=blob:none -q https' in caplog.text
         assert pytest_wrapped_e.value.code == 1
 
 def test_simple_with_reqs_txt_flip_ssh_no_ssh(lambda_paths, environments, context_modified_environ,


### PR DESCRIPTION
**Summary**
Add a docker image for python 3.9, enable GitHub workflows to detect failed testing and conditionally push images only if the testing was successful and fix a python unit test that had been failing but not detected.

**Changes**:
- Added a docker image for python 3.9
- Updated the README.md file to reflect the new image availability
- Updated the python_packager.md file to reference the 'python-latest' image instead of a static image that was way out of date
- Updated the GitHub workflows python images for 3.9 to also have the 'latest' tag and added a 'python-latest' tag to match the 'node-latest' tag and so that the tag would have a more meaningful context.
- Added conditional step testing in the GitHub workflows to detect failed build/tests and to only push images that passed
- Fixed the python test script to correctly check a commands status and then to exit the script if the exit status is anything but 0 (successful)
- Fixed the test image tags to actually include the git commit sha as intended
- Modified a couple of files for readability as well as adding additional comments

**Testing**:
- Built and tested each image locally (node/python) with all passing
- Validated that the modified python test.sh script would successfully detect a failed test command and then exit with a failed status
- Validated that the modified GitHub workflows would detect a failed exit status from the modified python test.sh script and not push the failed image
- The GitHub workflows passed from the last commit and successfully pushed the images