### PR TITLE
replace literal_eval with strtobool for config booleans

### DIFF
--- a/python/entrypoint.py
+++ b/python/entrypoint.py
@@ -15,7 +15,7 @@ from shutil import which
 from typing import Set
 from pathlib import Path
 from os.path import join, split
-from ast import literal_eval
+from distutils.util import strtobool
 from functools import lru_cache
 from multiprocessing import Process
 
@@ -118,10 +118,10 @@ def extract_container_variables(container_vars: dict) -> dict:
         "max_lambda_size": int(
             container_vars.get('MAX_LAMBDA_SIZE_BYTES', defaults['DEFAULT_MAX_LAMBDA_SIZE'])
         ),
-        "fail_on_too_big": literal_eval(str(
+        "fail_on_too_big": (1 == strtobool(str(
             container_vars.get('FAIL_ON_TOO_BIG', defaults['DEFAULT_FAIL_ON_TOO_BIG'])
-        )),
-        "ssh_flip": literal_eval(str(container_vars.get('SSH_FLIP', defaults['DEFAULT_SSH_FLIP']))),
+        ))),
+        "ssh_flip": (1 == strtobool(str(container_vars.get('SSH_FLIP', defaults['DEFAULT_SSH_FLIP'])))),
     }
 
     return container_variables


### PR DESCRIPTION
distutils.util.strtobool(val)
Convert a string representation of truth to true (1) or false (0).

True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0. Raises [ValueError](https://docs.python.org/3.7/library/exceptions.html#ValueError) if val is anything else.

see: https://docs.python.org/3.7/distutils/apiref.html

